### PR TITLE
Update Ubuntu runner version and set timeout for scheduled workflows

### DIFF
--- a/.github/workflows/scheduled-plot-ganttchart.yml
+++ b/.github/workflows/scheduled-plot-ganttchart.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+    timeout-minutes: 360
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/scheduled-plot-stats.yml
+++ b/.github/workflows/scheduled-plot-stats.yml
@@ -7,9 +7,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
+    timeout-minutes: 360
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
#4 への対応